### PR TITLE
Switch `main` to JakartaEE (instead of JavaEE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jfclere/tomcat10-builder:latest
+FROM quay.io/jfclere/tomcat10-builder:latest
 LABEL Description="Tomcat webapp image to use with the JWS operator"
 VOLUME /tmp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM quay.io/jfclere/tomcat10-builder:latest
+FROM quay.io/jfclere/image-builder-jws
 LABEL Description="Tomcat webapp image to use with the JWS operator"
 VOLUME /tmp
 
-RUN git clone https://github.com/jfclere/demo-webapp.git
+RUN uname -a
 
-RUN (cd demo-webapp; export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64; mvn install; cp target/demo-1.0.war /deployments/ROOT.war)
+RUN git clone https://github.com/web-servers/demo-webapp.git
+
+RUN (cd demo-webapp; mvn install; cp target/demo-1.0.war /deployments/ROOT.war)
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM jfclere/tomcat10-builder:latest
+LABEL Description="Tomcat webapp image to use with the JWS operator"
+VOLUME /tmp
+
+RUN git clone https://github.com/jfclere/demo-webapp.git
+
+RUN (cd demo-webapp; export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64; mvn install; cp target/demo-1.0.war /deployments/ROOT.war)

--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ mvn package
 # builds  `target/demo-1.0.war`
 ```
 
+# Dockerfile
+The dockerfile just building a war in /tmp, it is for testing purpose, if you want something usable look to the JWS operator script.
+

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ mvn package
 # builds  `target/demo-1.0.war`
 ```
 
+# Branches
+
+The `main` branch uses JakartaEE version of the application. In case you would like to use JavaEE variant,
+there is a `javaEE` branch for you to use.
+
 # Dockerfile
 The dockerfile just building a war in /tmp, it is for testing purpose, if you want something usable look to the JWS operator script.
+
 

--- a/custom_resource.yaml
+++ b/custom_resource.yaml
@@ -9,7 +9,7 @@ spec:
     applicationImage: quay.io/jfclere/tomcat10:latest
     webApp:
       sourceRepositoryURL: https://github.com/jfclere/demo-webapp
-      # sourceRepositoryRef is not required by default but it is needed to get the correct source code for the webapp
-      sourceRepositoryRef: "jakartaEE"
+      # where to put the built image (you need to have set the right default secrets).
+      webAppWarImage: quay.io/jfclere/tomcat-demo
       builder:
-        image: maven:3.8.1-openjdk-8
+        image: quay.io/jfclere/image-builder-jws

--- a/loadbalancer.yaml
+++ b/loadbalancer.yaml
@@ -9,6 +9,7 @@ spec:
     targetPort: 8080
   selector:
     WebServer: tomcatdemo
+    deploymentConfig: tomcat-demo
   sessionAffinity: None
   type: LoadBalancer
 status:

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <url>http://maven.apache.org</url>
 
   <properties>
-      <tomcat.version>9.0.22</tomcat.version>
+      <tomcat.version>10.0.6</tomcat.version>
   </properties>
 
    <build>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
+                    <encoding>UTF-8</encoding>
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -26,13 +26,11 @@
                     <target>11</target>
                 </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
-
         </plugins>
    </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <url>http://maven.apache.org</url>
 
   <properties>
-      <tomcat.version>10.0.6</tomcat.version>
+      <tomcat.version>10.1.33</tomcat.version>
   </properties>
 
    <build>
@@ -19,11 +19,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.13.0</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
 

--- a/src/main/java/org/example/tomcat/cloud/TestServlet.java
+++ b/src/main/java/org/example/tomcat/cloud/TestServlet.java
@@ -16,13 +16,13 @@
 
 package org.example.tomcat.cloud;
 
-import javax.servlet.annotation.WebServlet;
+import jakarta.servlet.annotation.WebServlet;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import java.io.IOException;
 import java.io.PrintWriter;


### PR DESCRIPTION
close #6 

This will switch the `main` branch to Jakarta. The current `main` is already preserved in `javaEE` branch that is now protected.

I tried to fix the paths and branches so that it will work with `main` directly after merge because I want to delete `jakartaEE` branch afterwards.

Hopefully, I didn't miss anything...